### PR TITLE
Corrected dependencies from '=>' to '>='

### DIFF
--- a/shoppe.gemspec
+++ b/shoppe.gemspec
@@ -16,15 +16,15 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.0.0", "< 5.0"
   s.add_dependency "bcrypt", ">= 3.1.2", "< 3.2"
-  s.add_dependency "ransack", "=> 1.2.0", "< 1.3"
+  s.add_dependency "ransack", ">= 1.2.0", "< 1.3"
   s.add_dependency "kaminari", ">= 0.14.1", "< 0.16"
-  s.add_dependency "haml", "=> 4.0", "< 5.0"
+  s.add_dependency "haml", ">= 4.0", "< 5.0"
   s.add_dependency "dynamic_form", '~> 1.1', '>= 1.1.4'
   s.add_dependency "jquery-rails", ">= 3", "< 4"
   s.add_dependency "roo", ">= 1.13.0", "< 1.14"
 
   s.add_dependency "nifty-key-value-store", ">= 1.0.1", "< 2.0.0"
-  s.add_dependency "nifty-utils", "=> 1.0", "< 1.1"
+  s.add_dependency "nifty-utils", ">= 1.0", "< 1.1"
   s.add_dependency "nifty-attachments", ">= 1.0.3", "< 2.0.0"
   s.add_dependency "nifty-dialog", '>= 1.0.7', '< 1.1'
 


### PR DESCRIPTION
Was getting this error on `bundle install`:

```
There was a Gem::Requirement::BadRequirementError while loading shoppe.gemspec:
Illformed requirement ["=> 1.2.0"]
```
